### PR TITLE
fixed tests for resources navbar

### DIFF
--- a/features/navbar.feature
+++ b/features/navbar.feature
@@ -20,8 +20,13 @@ Feature: When I visit a page with a navbar, the links should be clickable and le
     Then I should see Calendar Stub
     And I should not see Core Members
 #
-  Scenario: visiting the resources page
+  Scenario: visiting the resources page when not logged in
     Given I am on the home page
+    Then I should not see Resources
+    
+  Scenario: visiting the resources page when logged in
+    Given I am on the home page
+    And I am logged in
     When I follow Resources
     Then I should see Resources
 


### PR DESCRIPTION
Changed tests so that correct functionality is tested: Should not see Resources on navbar when not logged in, should see it only when logged in.