### PR TITLE
Restrict resource page

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,4 +1,5 @@
 class ResourcesController < ApplicationController
+  before_filter :authenticate_user!
   def index
     @resources = Resource.all
   end


### PR DESCRIPTION
Added an authentication check in the resources controller so if a user manually navigates to the resources page (by adding '/resources'), they will be redirected to the sign-in page with a message telling them they need to sign in to continue