### PR TITLE
ag-Hide 'Delete' link for non-core members

### DIFF
--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -26,7 +26,9 @@
          <tr>
             <td><%= resource.title %></td>
             <td><%= link_to "Download Resource", resource.attachment_url %></td>
-            <td><%= button_to "Delete",  resource, method: :delete, class: "btn btn-danger", confirm: "Are you sure that you wish to delete #{resource.title}?" %></td>
+            <% if @core_member %>
+              <td><%= button_to "Delete",  resource, method: :delete, class: "btn btn-danger", confirm: "Are you sure that you wish to delete #{resource.title}?" %></td>
+            <%end%>
          </tr>
          
       <% end %>


### PR DESCRIPTION
made the delete link only visible if current user is a core member